### PR TITLE
Android touch to unlock not showing in menu (Support) #89

### DIFF
--- a/source/shared/touchUnlock.js
+++ b/source/shared/touchUnlock.js
@@ -114,7 +114,7 @@ function removeSourceFromKeychainCredentials(keychainCreds, sourceID) {
 export function touchIDAvailable() {
     return TouchID.isSupported()
         .then(supportCode => {
-            return supportCode === "FaceID" || supportCode === "TouchID";
+            return supportCode === "FaceID" || supportCode === "TouchID" || supportCode === true;
         })
         .catch(err => {
             return false;


### PR DESCRIPTION
resolved issue of menu option not showing up for android 

tested on my pixel 2 ... touch available and works 

Fixes #89 