### PR TITLE
Remove wrong arch from build.gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -127,7 +127,7 @@ android {
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
             // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits
-            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3]
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2]
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -104,7 +104,7 @@ android {
         versionCode 8
         versionName "1.3.0"
         ndk {
-            abiFilters "armeabi-v7a", "arm64-v8a", "x86"
+            abiFilters "armeabi-v7a", "x86"
         }
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
@@ -113,7 +113,7 @@ android {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
             universalApk false  // If true, also generate a universal APK
-            include "armeabi-v7a", "arm64-v8a", "x86"
+            include "armeabi-v7a", "x86"
         }
     }
     buildTypes {


### PR DESCRIPTION
While developing the rust library and when it wasn't working correctly, I added an extra architecture to `abiFilters` in build.gradle file without knowing what it does exactly. Turns out it has nothing to do with our Rust library and it's related to React Native itself. 

Thats why the app was dying on specific phones. I reverted build.gradle to it's previous version and the problem was solved.