### PR TITLE
Update core version - fix crashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Buttercup",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -796,7 +796,7 @@
         "gzip-js": "0.3.2",
         "pify": "3.0.0",
         "url-join": "4.0.0",
-        "webdav": "1.5.2"
+        "webdav": "1.5.3"
       },
       "dependencies": {
         "pify": {
@@ -2279,9 +2279,9 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
     "buttercup": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/buttercup/-/buttercup-2.0.4.tgz",
-      "integrity": "sha512-DWIc04RA/um3kqiQanE5TPNTe7E3cobGHi9L5x30pVQGgWqrBfYdfVtDNAysDtI+Bx3xWBNHWQ12/Wc7ShggfQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/buttercup/-/buttercup-2.3.0.tgz",
+      "integrity": "sha512-kHEA/HNulXgqdTOnwtekhYMA0/WcvoBVyOPMAOUPvuYDjOly4mD1Ca2Z4Aomr/xKCa7jTo1zY3k8Y8mMIGI2nA==",
       "requires": {
         "@buttercup/channel-queue": "0.2.2",
         "@buttercup/credentials": "1.1.1",
@@ -2291,7 +2291,7 @@
         "fuse.js": "2.7.4",
         "iocane": "1.0.0",
         "node-fetch": "2.1.2",
-        "node-rsa": "1.0.0",
+        "node-rsa": "1.0.1",
         "string-hash": "1.1.3",
         "url-join": "4.0.0",
         "uuid": "3.2.1",
@@ -8198,9 +8198,9 @@
       }
     },
     "node-rsa": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.0.0.tgz",
-      "integrity": "sha512-xCk0QUCd7odKC+bWjW0Gm9x/E1Ti3HRsWSjkaKL9JE0aEjpuAa5OTNFiCzSat8sh7dGWIqyka/+070n+UHLyiw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.0.1.tgz",
+      "integrity": "sha512-8iKs0HgkufO4Qb1iUJChh7Dg8HcSDVD37p3yu1tAhYa+/n2CwG9/d3qE+h6OHAIsfkXHEYYgbf4c7NfoMKayng==",
       "requires": {
         "asn1": "0.2.3"
       }
@@ -11931,9 +11931,9 @@
       }
     },
     "webdav": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/webdav/-/webdav-1.5.2.tgz",
-      "integrity": "sha512-x81G3ahrTwM8FIkMkT93YbEQM6/BoN7O7z6WkHHVX1ZkN0OA/wzSrUtpB2LMVk77hsuw1u1hRqkKee/rG2hErQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/webdav/-/webdav-1.5.3.tgz",
+      "integrity": "sha512-33ElaSjfby6uhcPxNq0F3sTjVuvNbDK5zQeKZcV4wfruSvui132zUXaFmatqOnjnZLaKafHmjQdHd6pcYPJXyQ==",
       "requires": {
         "merge": "1.2.0",
         "node-fetch": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "assert": "^1.4.1",
     "browserify-zlib": "^0.1.4",
     "buffer": "^3.6.0",
-    "buttercup": "^2.0.4",
+    "buttercup": "^2.3.0",
     "console-browserify": "^1.1.0",
     "constants-browserify": "0.0.1",
     "dns.js": "^1.0.1",

--- a/source/components/AddMetaPage.js
+++ b/source/components/AddMetaPage.js
@@ -12,7 +12,7 @@ const styles = StyleSheet.create({
 
 class AddMetaPage extends Component {
     static navigationOptions = {
-        title: "Add Meta",
+        title: "Add Custom Properties",
         headerRight: <Button title="Save" onPress={saveNewMeta} />
     };
 

--- a/source/components/AddMetaPage.js
+++ b/source/components/AddMetaPage.js
@@ -12,7 +12,7 @@ const styles = StyleSheet.create({
 
 class AddMetaPage extends Component {
     static navigationOptions = {
-        title: "Add Custom Properties",
+        title: "Add Property",
         headerRight: <Button title="Save" onPress={saveNewMeta} />
     };
 


### PR DESCRIPTION
Updates the core lib version to 2.3.0 - fixes #112 

Issue was related to an older check of entry property names, which was flagging some characters as invalid. It may have been uppercase characters which caused #112 in the first place.