### PR TITLE
#137 - Touch ID constantly appearing

### DIFF
--- a/ios/AutoFillHelpers.m
+++ b/ios/AutoFillHelpers.m
@@ -17,9 +17,9 @@
 @implementation AutoFillHelpers
 
 NSString *authenticationPrompt = @"";
-NSString *key = @"pw.buttercup.mobile.autofillstore";
-NSString *service = @"pw.buttercup.mobile.autofillstore";
-NSString *accessGroup = @"group.pw.buttercup.mobile";
+NSString *key = @"se1exin.pw.buttercup.mobile.autofillstore";
+NSString *service = @"se1exin.pw.buttercup.mobile.autofillstore";
+NSString *accessGroup = @"group.se1exin.pw.buttercup.mobile";
 
 + (bool) deviceSupportsAutoFill
 {
@@ -44,32 +44,32 @@ NSString *accessGroup = @"group.pw.buttercup.mobile";
 + (NSDictionary *) getAutoFillEntries
 {
     NSDictionary *emptyDictionary = [[NSDictionary alloc] init];
-
+    
     NSDictionary *query = [self buildKeychainQuery];
-
+    
     // Look up service in the keychain
     NSDictionary *found = nil;
     CFTypeRef foundTypeRef = NULL;
     OSStatus osStatus = SecItemCopyMatching((__bridge CFDictionaryRef) query, (CFTypeRef*)&foundTypeRef);
-
+    
     if (osStatus != noErr && osStatus != errSecItemNotFound) {
         return emptyDictionary; // Return an empty dictionary if errors are encountered
     }
-
+    
     found = (__bridge NSDictionary*)(foundTypeRef);
     if (!found) {
         return emptyDictionary; // Return an empty dictionary if nothing is found
     }
-
+    
     // Grab the JSON encoded value and decode into a dictionary
     NSError *jsonError;
     NSString *value = [[NSString alloc] initWithData:[found objectForKey:(__bridge id)(kSecValueData)] encoding:NSUTF8StringEncoding];
     NSData *objectData = [value dataUsingEncoding:NSUTF8StringEncoding];
-
+    
     NSDictionary *json = [NSJSONSerialization JSONObjectWithData:objectData
                                                          options:NSJSONReadingMutableContainers
                                                            error:&jsonError];
-
+    
     // Return the valid JSON Dictionary, or the empty dictionary if deserialization failed
     return (!json ? emptyDictionary : json);
 }
@@ -84,52 +84,26 @@ NSString *accessGroup = @"group.pw.buttercup.mobile";
     if (! jsonData) {
         return error;
     }
-
+    
     NSString *value = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-
+    
     // First try to delete any existing entries
     NSDictionary *query = [self buildKeychainQuery];
     SecItemDelete((__bridge CFDictionaryRef) query);
-
+    
     // Now try to save to keychain again
     CFStringRef accessible = kSecAttrAccessibleWhenUnlocked;
-    SecAccessControlCreateFlags accessControl = kSecAccessControlTouchIDAny|kSecAccessControlOr|kSecAccessControlDevicePasscode;
-
     NSDictionary *attributes = @{
                                  (__bridge NSString *)kSecClass: (__bridge id)(kSecClassGenericPassword),
                                  (__bridge NSString *)kSecAttrService: service,
                                  (__bridge NSString *)kSecAttrAccount: key,
                                  (__bridge NSString *)kSecAttrAccessGroup: accessGroup,
-                                 (__bridge NSString *)kSecValueData: [value dataUsingEncoding:NSUTF8StringEncoding],
+                                 (__bridge NSString *)kSecAttrAccessible: (__bridge id)accessible,
+                                 (__bridge NSString *)kSecValueData: [value dataUsingEncoding:NSUTF8StringEncoding]
                                  };
-
-    NSMutableDictionary *mAttributes = attributes.mutableCopy;
-
-    if (accessControl) {
-        NSError *aerr = nil;
-        BOOL canAuthenticate = [[LAContext new] canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&aerr];
-        if (aerr || !canAuthenticate) {
-            return false;
-        }
-
-        CFErrorRef error = NULL;
-        SecAccessControlRef sacRef = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
-                                                                     accessible,
-                                                                     accessControl,
-                                                                     &error);
-
-        if (error) {
-            return aerr;
-        }
-        mAttributes[(__bridge NSString *)kSecAttrAccessControl] = (__bridge id)sacRef;
-    } else {
-        mAttributes[(__bridge NSString *)kSecAttrAccessible] = (__bridge id)accessible;
-    }
-
-    attributes = [NSDictionary dictionaryWithDictionary:mAttributes];
-
+    
     OSStatus osStatus = SecItemAdd((__bridge CFDictionaryRef) attributes, NULL);
-
+    
     if (osStatus != noErr && osStatus != errSecItemNotFound) {
         NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:osStatus userInfo:nil];
         return error;
@@ -143,20 +117,20 @@ NSString *accessGroup = @"group.pw.buttercup.mobile";
     if ([self deviceSupportsAutoFill]) {
         // Iterate the entries and add them to the ASCredentialIdentityStore
         ASCredentialIdentityStore *store = [ASCredentialIdentityStore sharedStore];
-
+        
         NSMutableArray *credentialIdenties = [[NSMutableArray alloc] init];
-
+        
         // Iterate the each Source in the autoFillEntries object
         [autoFillEntries enumerateKeysAndObjectsUsingBlock:^(NSString* sourceID, NSDictionary* childEntries, BOOL* outerStop) {
             // Then iterate each child entrie of the source to create the final ASCredentialServiceIdentifier
             [childEntries enumerateKeysAndObjectsUsingBlock:^(NSString* entryID, NSDictionary* entry, BOOL* innerStop) {
                 // Create the service identifier for the entry
-
+                
                 // Set the record identifier based on the Source and Entry IDs so we can easily map back to this entry
                 // Format: sourceID:entryID
                 NSString *recordIdentifier = [NSString stringWithFormat:@"%@:%@", sourceID, entryID];
                 NSString *username = [entry valueForKey:@"username"];
-
+                
                 if (username != nil && ![username isEqualToString:@""]) {
                     // Add a service identifier for every URL associated with the Entry
                     NSArray *urls = [entry objectForKey:@"urls"];
@@ -167,12 +141,12 @@ NSString *accessGroup = @"group.pw.buttercup.mobile";
                                 ASCredentialServiceIdentifier *serviceIdentifier = [[ASCredentialServiceIdentifier alloc]
                                                                                     initWithIdentifier:url
                                                                                     type:ASCredentialServiceIdentifierTypeURL];
-
+                                
                                 ASPasswordCredentialIdentity *identity = [[ASPasswordCredentialIdentity alloc]
                                                                           initWithServiceIdentifier:serviceIdentifier
                                                                           user:username
                                                                           recordIdentifier:recordIdentifier];
-
+                                
                                 [credentialIdenties addObject:identity];
                             }
                         }];
@@ -190,15 +164,15 @@ NSString *accessGroup = @"group.pw.buttercup.mobile";
  * Take a ASPasswordCredentialIdentity try to reverse match a Buttercup credential using the ASPasswordCredentialIdentity recordIdentifier
  */
 + (ASPasswordCredential *) getAutoFillPasswordCredential:(ASPasswordCredentialIdentity *)credentialIdentity
- API_AVAILABLE(ios(12.0)) {
-     // Obtain the Source ID and Entry ID from the recordIdentifier
+API_AVAILABLE(ios(12.0)) {
+    // Obtain the Source ID and Entry ID from the recordIdentifier
     NSArray *identifierParts = [[credentialIdentity recordIdentifier] componentsSeparatedByString:@":"];
     if ([identifierParts count] == 2) { // Check that the split was successful
         NSDictionary *autoFillEntries = [self getAutoFillEntries];
-
+        
         NSString *sourceID = identifierParts[0];
         NSString *entryID = identifierParts[1];
-
+        
         // Check for a matching Buttercup entry
         if (autoFillEntries[sourceID] && autoFillEntries[sourceID][entryID]) {
             // Final check that username and password are present

--- a/ios/AutoFillHelpers.m
+++ b/ios/AutoFillHelpers.m
@@ -17,9 +17,9 @@
 @implementation AutoFillHelpers
 
 NSString *authenticationPrompt = @"";
-NSString *key = @"se1exin.pw.buttercup.mobile.autofillstore";
-NSString *service = @"se1exin.pw.buttercup.mobile.autofillstore";
-NSString *accessGroup = @"group.se1exin.pw.buttercup.mobile";
+NSString *key = @"pw.buttercup.mobile.autofillstore";
+NSString *service = @"pw.buttercup.mobile.autofillstore";
+NSString *accessGroup = @"group.pw.buttercup.mobile";
 
 + (bool) deviceSupportsAutoFill
 {


### PR DESCRIPTION
This PR should fix the issue of Touch/FaceID constantly appearing, mentioned in #137.

The issue was the custom Keychain implementation forcing biometrics when ever credentials were replicated to the iOS credential store (whenever an archive is opened changed). The biometric check has been removed.