### PR TITLE
#179 - Link missing rnGoogleSignin.a in Autofill Extension Project

### DIFF
--- a/ios/Buttercup.xcodeproj/project.pbxproj
+++ b/ios/Buttercup.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		9E44190C21E042A000CA5E79 /* AutoFillHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E44190A21E042A000CA5E79 /* AutoFillHelpers.m */; };
 		9E44191021E177CA00CA5E79 /* AutoFillExtensionContextBridgeDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E44190F21E177CA00CA5E79 /* AutoFillExtensionContextBridgeDelegate.m */; };
 		9E44E8E62217990D00BB8F64 /* AutoFillBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E4418DB21E0215500CA5E79 /* AutoFillBridge.m */; };
+		9EFEB97C2324872C00463B64 /* libRNGoogleSignin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C24863EA2311ABDE00CE94EF /* libRNGoogleSignin.a */; };
 		BBC4A737D75245BFB27E789A /* MaterialCommunityIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0DDEC782F5AC468DB7A1AD40 /* MaterialCommunityIcons.ttf */; };
 		BEB97DFEB83643518C9C49E2 /* libRNRandomBytes.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DDF6BBB133149AC94941F54 /* libRNRandomBytes.a */; };
 		C26F52C11F5736CE000EB570 /* BCHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = C26F52BF1F5736CE000EB570 /* BCHelpers.m */; };
@@ -619,6 +620,7 @@
 				9E13611421DC437500EE48B0 /* libRNRandomBytes.a in Frameworks */,
 				9E13611621DC437C00EE48B0 /* libTouchID.a in Frameworks */,
 				9E13615A21DC465E00EE48B0 /* libRNSecureStorage.a in Frameworks */,
+				9EFEB97C2324872C00463B64 /* libRNGoogleSignin.a in Frameworks */,
 				692EF8BEC14F192BD40C0BC2 /* Pods_BCAutoFillExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
It appears that the autofill extension is not loading due to the `rnGoogleSignin.a` library not being linked in the `BCAutoFillExtension` iOS Target.

I wouldn't blame you for not noticing this one! I'm not sure if I even mentioned that new native libs would also need to be linked to the (at the time) new `BCAutoFillExtension` iOS Target. Sorry if I failed to mention it before!!!

@perry-mitchell Please give this a thorough test on your Google Drive `secrets.json` - as I was not actually able to complete a full Google Drive setup flow with my testing oauth credentials. By the look of it the issue was simply the missing linkage, and a not a memory issue as we previous had suspected, so I would rather ask you to verify it is fixed before spending time on potentially unneeded Google APIs setup etc.

<img width="825" alt="Screen Shot 2019-09-08 at 10 54 44 am" src="https://user-images.githubusercontent.com/2385350/64481785-1b97c700-d227-11e9-8748-8120c120685e.png">


