### PR TITLE
Remove SYSTEM_ALERT_WINDOW permission request

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -118,11 +118,13 @@ android {
     }
     buildTypes {
         debug {
-            // Fix for RN Debug on Android 8 - https://stackoverflow.com/questions/45940861/android-8-cleartext-http-traffic-not-permitted/50834600#50834600
-            manifestPlaceholders = [usesCleartextTraffic:"true"]
+            manifestPlaceholders = [
+                    usesCleartextTraffic:"true", // Fix for RN Debug on Android 8 - https://stackoverflow.com/questions/45940861/android-8-cleartext-http-traffic-not-permitted/50834600#50834600
+                    excludeSystemAlertWindowPermission: "false" // Fix for stripping unwanted permissions - https://github.com/facebook/react-native/issues/5886#issuecomment-224397883
+            ]
         }
         release {
-            manifestPlaceholders = [usesCleartextTraffic:"false"]
+            manifestPlaceholders = [usesCleartextTraffic:"false", excludeSystemAlertWindowPermission: "true"]
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.buttercup">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:remove="${excludeSystemAlertWindowPermission}"/>
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
 
     <application

--- a/android/app/src/main/java/com/buttercup/MainActivity.java
+++ b/android/app/src/main/java/com/buttercup/MainActivity.java
@@ -4,9 +4,6 @@ import com.facebook.react.ReactActivity;
 import org.spongycastle.jce.provider.BouncyCastleProvider;
 import java.security.Security;
 
-import android.provider.Settings;
-import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.content.pm.PackageManager;
 import android.os.Build;
@@ -15,7 +12,6 @@ import android.widget.Toast;
 public class MainActivity extends ReactActivity {
 
     public static final int PERMISSION_REQ_CODE = 1234;
-    public static final int OVERLAY_PERMISSION_REQ_CODE = 1235;
 
     String[] perms = {
             "android.permission.READ_EXTERNAL_STORAGE",
@@ -55,16 +51,6 @@ public class MainActivity extends ReactActivity {
         System.out.println("Checking perms");
         // Checking if device version > 22 and we need to use new permission model
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1) {
-            // Checking if we can draw window overlay
-            if (!Settings.canDrawOverlays(this)) {
-                System.out.println("Can't draw overlays");
-                // Requesting permission for window overlay(needed for all react-native apps)
-                Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                        Uri.parse("package:" + getPackageName()));
-                startActivityForResult(intent, OVERLAY_PERMISSION_REQ_CODE);
-                closeApplication();
-                return;
-            }
             for (String perm : perms){
                 // Checking each permission and if denied then requesting permissions
                 if (checkSelfPermission(perm) == PackageManager.PERMISSION_DENIED){
@@ -72,15 +58,6 @@ public class MainActivity extends ReactActivity {
                     break;
                 }
             }
-        }
-    }
-
-    // Window overlay permission intent result
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == OVERLAY_PERMISSION_REQ_CODE) {
-            checkPerms();
         }
     }
 


### PR DESCRIPTION
Fixes #184 by removing the `SYSTEM_ALERT_WINDOW` permission in release builds, and removing the permission request entirely.

I've tested as much of the app (with a Dropbox archive) as I could, including autofill, and everything seems to work fine without the permission.