### PR TITLE
Change icon names to match ionicon icons (Fixes #187)

### DIFF
--- a/source/components/EntryPage.js
+++ b/source/components/EntryPage.js
@@ -21,9 +21,9 @@ const styles = StyleSheet.create({
 function iconLabelForProp(propName) {
     switch (propName.toLowerCase()) {
         case "username":
-            return "face";
+            return "person";
         case "password":
-            return "fingerprint";
+            return "finger-print";
         case "title":
             return "layers";
         case "url":


### PR DESCRIPTION
This PR fixes the broken icons identified in issue #187 

After a bit of a dig :mag: I've found the issue was caused by [the upgrade of `react-native-cell-components`](https://github.com/buttercup/buttercup-mobile/commit/2c02156bf3f7698ea982e6c732477cb83827a22f#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R57) in Buttercup Mobile, which introduced [a commit in the upstream project](https://github.com/lodev09/react-native-cell-components/commit/a981a19a7dcb2e7ffb1170a9df9973689b2307d5#diff-8c6384ea362aeca7173233175b8a1441R60) that changes the default Icon package to `Ionicons`.

The changed icon package uses different names for the `fingerprint` and `face` icons, this commit updates the references to the correct names.

Tested and verified on both iOS and Android.


