### PR TITLE
Add search icon in header when viewing archives

### DIFF
--- a/source/components/GroupsPage.js
+++ b/source/components/GroupsPage.js
@@ -5,6 +5,7 @@ import Prompt from "@perrymitchell/react-native-prompt";
 import { Cell, CellGroup } from "react-native-cell-components";
 import { editGroup } from "../shared/archiveContents.js";
 import { rawGroupIsTrash } from "../shared/group.js";
+import { gotoSearch } from "../shared/entries.js";
 import Spinner from "./Spinner.js";
 import EmptyView from "./EmptyView.js";
 import ToolbarIcon from "./ToolbarIcon.js";
@@ -14,6 +15,7 @@ const GROUP_ICON = require("../../resources/images/group-256.png");
 const TRASH_ICON = require("../../resources/images/trash-256.png");
 const MENU_ICON = require("../../resources/images/menu.png");
 const KEY_IMAGE = require("../../resources/images/key.png");
+const SEARCH = require("../../resources/images/search.png");
 
 const styles = StyleSheet.create({
     container: {
@@ -34,15 +36,22 @@ function getGroupIcon(group) {
     return <Image source={icon} style={styles.icon} />;
 }
 
+function getHeaderRight(groupID) {
+    return (
+        <>
+            <ToolbarIcon icon={SEARCH} onPress={gotoSearch} />
+            <ToolbarIcon icon={MENU_ICON} onPress={() => editGroup(groupID)} />
+        </>
+    );
+}
+
 class GroupsPage extends Component {
     static navigationOptions = ({ navigation }) => {
         const { params = {} } = navigation.state;
         const { groupID = "0", title, isTrash } = params;
         const options = { title };
         if (!isTrash) {
-            options.headerRight = (
-                <ToolbarIcon icon={MENU_ICON} onPress={() => editGroup(groupID)} />
-            );
+            options.headerRight = getHeaderRight(groupID);
         }
         return options;
     };

--- a/source/shared/entries.js
+++ b/source/shared/entries.js
@@ -1,8 +1,13 @@
 import extractDomain from "extract-domain";
 import { getSharedArchiveManager } from "../library/buttercup.js";
 import { EntryFinder } from "../library/buttercupCore.js";
-import { getState } from "../store.js";
+import { dispatch, getState } from "../store.js";
+import { navigateToSearchArchives } from "../actions/navigation.js";
 import { getSelectedArchive } from "../selectors/archiveContents.js";
+
+export function gotoSearch() {
+    dispatch(navigateToSearchArchives());
+}
 
 export function getNameForSource(sourceID) {
     const source = getSharedArchiveManager().getSourceForID(sourceID);


### PR DESCRIPTION
This is a go at solving https://github.com/buttercup/buttercup-mobile/issues/195. See screenshot below:

<img width="286" alt="Skjermbilde 2019-11-17 00 00 33" src="https://user-images.githubusercontent.com/1738405/69000377-00080700-08cf-11ea-9dd2-473dc82389a1.png">

Clicking the search icon takes you to the "Search Vaults" screen, which is the same as happens when clicking the burger icon  and then "Search Vault".  I don't know if it is better to limit the search to the current group shown, but I did not see an easy way to do that.