### PR TITLE
Small UX improvements to Vault Password prompt

### DIFF
--- a/source/components/ArchivesList.js
+++ b/source/components/ArchivesList.js
@@ -343,7 +343,11 @@ class ArchivesList extends Component {
                     visible={this.props.showUnlockPrompt}
                     onCancel={() => this.props.showUnlockPasswordPrompt(false)}
                     onSubmit={pass => this.handlePasswordEntered(pass)}
-                    textInputProps={{ secureTextEntry: true }}
+                    textInputProps={{
+                        autoCapitalize: "none",
+                        autoFocus: true,
+                        secureTextEntry: true
+                    }}
                     inputStyle={{ color: "#000" }}
                 />
                 <Spinner visible={this.props.busyState !== null} text={this.props.busyState} />


### PR DESCRIPTION
On Android 10 with [AnySoftKeyboard](https://anysoftkeyboard.github.io/) the keyboard auto-capitalizes the first word of the vault password when unlocking a vault.
It's a minor issue, but it's still frustrating to encounter every time you want to unlock a vault.
This PR solves the issue by providing some props to the TextInput of the password prompt.