### PR TITLE
Fix issue #242: show groups hierarchical instead of flat

### DIFF
--- a/source/selectors/archiveContents.js
+++ b/source/selectors/archiveContents.js
@@ -9,9 +9,10 @@ function getEntries(state) {
 }
 
 export function getGroup(state, id, _groups = null) {
-    const groups = _groups || getGroups(state);
+    const allGroups = _groups || getGroups(state);
     const allEntries = getEntries(state);
     if (id === "0") {
+        const groups = allGroups.filter(group => group.parentID === id) || [];
         return {
             id: "0",
             title: "[archive]",
@@ -19,24 +20,26 @@ export function getGroup(state, id, _groups = null) {
             entries: []
         };
     }
-    const targetGroup = groups.find(group => group.id === id);
+    const targetGroup = allGroups.find(group => group.id === id);
     if (targetGroup) {
         const entries = allEntries.filter(entry => entry.parentID === targetGroup.id);
+        const groups = allGroups.filter(group => group.parentID === targetGroup.id) || [];
         return {
             id,
             title: targetGroup.title,
-            groups: targetGroup.groups ? sortGroups(targetGroup.groups) : [],
+            groups: sortGroups(groups),
             entries: sortEntries(entries)
         };
     }
-    for (let i = 0, groupCount = groups.length; i < groupCount; i += 1) {
-        const foundGroup = getGroup(state, id, groups[i].groups || []);
+    for (let i = 0, groupCount = allGroups.length; i < groupCount; i += 1) {
+        const foundGroup = getGroup(state, id, allGroups[i].groups || []);
         if (foundGroup) {
             const entries = allEntries.filter(entry => entry.parentID === foundGroup.id);
+            const groups = allGroups.filter(group => group.parentID === foundGroup.id) || [];
             return {
                 id,
                 title: foundGroup.title,
-                groups: foundGroup.groups ? sortGroups(foundGroup.groups) : [],
+                groups: sortGroups(groups),
                 entries: sortEntries(entries)
             };
         }

--- a/source/selectors/archiveContents.js
+++ b/source/selectors/archiveContents.js
@@ -40,24 +40,6 @@ export function getGroups(state) {
     return state[STATE_KEY].groups;
 }
 
-export function getGroupsUnderID(state, id) {
-    const groups = getGroups(state);
-    const findGroup = groups => {
-        let foundGroup = groups.find(group => group.id === id) || null;
-        if (!foundGroup) {
-            for (let i = 0, groupsLen = groups.length; i < groupsLen; i += 1) {
-                foundGroup = findGroup(groups[i].groups || []) || null;
-                if (foundGroup !== null) {
-                    break;
-                }
-            }
-        }
-        return foundGroup;
-    };
-    const foundGroup = id.toString() === "0" ? { groups } : findGroup(groups);
-    return foundGroup && foundGroup.groups ? sortGroups(foundGroup.groups) : [];
-}
-
 export function getSelectedArchive(state) {
     const id = getSelectedSourceID(state);
     const archiveManager = getSharedArchiveManager();

--- a/source/selectors/archiveContents.js
+++ b/source/selectors/archiveContents.js
@@ -31,19 +31,6 @@ export function getGroup(state, id, _groups = null) {
             entries: sortEntries(entries)
         };
     }
-    for (let i = 0, groupCount = allGroups.length; i < groupCount; i += 1) {
-        const foundGroup = getGroup(state, id, allGroups[i].groups || []);
-        if (foundGroup) {
-            const entries = allEntries.filter(entry => entry.parentID === foundGroup.id);
-            const groups = allGroups.filter(group => group.parentID === foundGroup.id) || [];
-            return {
-                id,
-                title: foundGroup.title,
-                groups: sortGroups(groups),
-                entries: sortEntries(entries)
-            };
-        }
-    }
     return null;
 }
 

--- a/source/selectors/archiveContents.js
+++ b/source/selectors/archiveContents.js
@@ -8,6 +8,8 @@ function getEntries(state) {
     return state[STATE_KEY].entries;
 }
 
+// Get the id, title, entries and subgroups of a group for the specified group id.
+// If the given id is "0" the base level of the archive is returned. In this case the list of entries is always empty.
 export function getGroup(state, id, _groups = null) {
     const allGroups = _groups || getGroups(state);
     const allEntries = getEntries(state);


### PR DESCRIPTION
Fix issue #242.

The groups in the redux state are a flat list of all groups (the groups in the state are set to the groups property of `createVaultFacade(vault)`).
But the existing code to show the archive contents expects a hierachical list of groups (i.e. each group has a groups property with a list of its subgroups).

This leads to the issue that all groups and subgroups are displayed flat in the application, and if a group is selected no subgroups are shown (because the selected group has no groups property with a list of its subgroups).

To fix this and get a hierarchival view in the application, filter the list of groups by the respective parentID. This is the exact same approach as for the entries.