### PR TITLE
Update for Android Autofill bridge

### DIFF
--- a/android/app/src/main/java/pw/buttercup/mobile/autofill/AutoFillActivity.java
+++ b/android/app/src/main/java/pw/buttercup/mobile/autofill/AutoFillActivity.java
@@ -7,9 +7,12 @@ import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JSIModulePackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.react.PackageList;
 import com.facebook.soloader.SoLoader;
+import com.swmansion.reanimated.ReanimatedJSIModulePackage;
+
 import org.spongycastle.jce.provider.BouncyCastleProvider;
 import java.security.Security;
 import java.util.Arrays;
@@ -53,6 +56,16 @@ public class AutoFillActivity extends ReactActivity {
                     packages.add(new CryptoPackage());
                     packages.add(new AutoFillPackage());
                     return packages;
+                }
+
+                @Override
+                protected String getJSMainModuleName() {
+                    return "index";
+                }
+
+                @Override
+                protected JSIModulePackage getJSIModulePackage() {
+                    return new ReanimatedJSIModulePackage();
                 }
             };
         }

--- a/android/app/src/main/java/pw/buttercup/mobile/autofill/AutoFillBridge.java
+++ b/android/app/src/main/java/pw/buttercup/mobile/autofill/AutoFillBridge.java
@@ -120,7 +120,7 @@ public class AutoFillBridge extends ReactContextBaseJavaModule {
 
             if (mAutofillManager != null) {
                 Intent intent = new Intent(Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE);
-                intent.setData(Uri.parse("package:com.buttercup"));
+                intent.setData(Uri.parse("package:pw.buttercup.mobile"));
                 requestPermissionsPromise = promise;
                 currentActivity.startActivityForResult(intent, AUTOFILL_REQ_CODE);
             } else {

--- a/source/App.tsx
+++ b/source/App.tsx
@@ -12,7 +12,7 @@ interface AppProps {
 }
 
 function _App(props: AppProps = {}) {
-    const isAutofill: boolean = useMemo(() => props.isContextAutoFill === 1, [props]);
+    const isAutofill: boolean = useMemo(() => [1, true].indexOf(props.isContextAutoFill) > -1, [props]);
     const handleCoverScreen = useCallback((appState: AppStateStatus) => {
         if (isAutofill) return;
         if (appState === "inactive" || appState === "background") {
@@ -20,6 +20,7 @@ function _App(props: AppProps = {}) {
         }
     }, [isAutofill]);
     useAppStateDebouncedCallback(handleCoverScreen);
+    console.log('isAutofill', isAutofill, props);
     if (isAutofill) {
         return (
             <AutofillApp

--- a/source/App.tsx
+++ b/source/App.tsx
@@ -20,7 +20,6 @@ function _App(props: AppProps = {}) {
         }
     }, [isAutofill]);
     useAppStateDebouncedCallback(handleCoverScreen);
-    console.log('isAutofill', isAutofill, props);
     if (isAutofill) {
         return (
             <AutofillApp

--- a/source/services/autofillBridge.tsx
+++ b/source/services/autofillBridge.tsx
@@ -3,6 +3,9 @@ import { NativeModules } from "react-native";
 import { IntermediateEntry, StoredAutofillEntries } from "../types";
 
 export interface AutofillBridgeInterface {
+    DEVICE_SUPPORTS_AUTOFILL: boolean;
+    getAutoFillSystemStatus: () => Promise<boolean>;
+    openAutoFillSystemSettings: () => Promise<void>;
     cancelAutoFill: () => Promise<void>;
     completeAutoFill: (username: string, password: string, entryPath: string) => Promise<void>;
     getEntriesForSourceID: (sourceID: VaultSourceID) => Promise<StoredAutofillEntries>;


### PR DESCRIPTION
@perry-mitchell Looks like you were just missing the initial calls to the AutofillBridge that request Android to add Buttercup as an Autofill provider to the device. I've also updated the `App.tsx` to correctly detect the flag to say it is being opened from Autofill.

Note I haven't tested the changes on iOS, but I don't see why it would do anything other than make it work better there as well.