### PR TITLE
Support using root CA certificates from Android user trust store

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="${usesCleartextTraffic}"
         android:requestLegacyExternalStorage="true"
+        android:networkSecurityConfig="@xml/network_security_config"
     >
         <activity
             android:name=".MainActivity"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Since Android 7.0 the user trust store is not included in the trusted anchors by default. This PR adds support to use root CA certificates installed in the Android user trust store to connect to Webdav vaults hosted on servers using certificates signed by private root CAs, using https. May also allow to use Buttercup with Webdav servers using self-signed certificates.

More information: https://developer.android.com/training/articles/security-config

Fixes https://github.com/buttercup/buttercup-mobile/issues/293 and most likely https://github.com/buttercup/buttercup-mobile/issues/159 as well.