### PR TITLE
Removed storage requests for Android 10+ when enabling autofill

### DIFF
--- a/source/components/screens/VaultSettingsScreen.tsx
+++ b/source/components/screens/VaultSettingsScreen.tsx
@@ -205,7 +205,7 @@ export function VaultSettingsScreen() {
     const handleAutofillActivation = useCallback(
         async (activated: boolean): Promise<void> => {
             if (activated) {
-                if (Platform.OS === "android") {
+               if (Platform.OS === "android" && Platform.Version < 29) {
                     const grantedStatus = await PermissionsAndroid.requestMultiple([
                         PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE,
                         PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE


### PR DESCRIPTION
This PR fixes #356
## Why is this needed
The READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE were replaced with Mediastore permissions in Android 10 (API level 29) and were completely deprecated in Android 13 (API level 33), so trying to request these permissions on Android 13 or higher will just result in the "Permissions not granted" error, See [Scoped Storage](https://developer.android.com/training/data-storage#scoped-storage) and [Breaking changes in Android 13](https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions)
## What this adds
I just added an additional check when enabling autofill to not try to request Storage permissions when Android version is 10 or higher (API level 29 or higher)